### PR TITLE
fix: update reference to direct type file

### DIFF
--- a/projects/validointi/core/src/lib/vestAdapter.ts
+++ b/projects/validointi/core/src/lib/vestAdapter.ts
@@ -1,4 +1,4 @@
-import { ValidationErrors } from '..';
+import { ValidationErrors } from './validator.types';
 
 interface VestLike<T> {
   (data: T | undefined, field?: string): any;


### PR DESCRIPTION
This is fixing the file refence from `..` to `./validators.types` 
