### PR TITLE
fix: :package: dont error on V17/18

### DIFF
--- a/projects/validointi/core/package.json
+++ b/projects/validointi/core/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/validointi/validointi/tree/main/projects/validointi/core"
   },
   "peerDependencies": {
-    "@angular/common": "^16.1.5",
-    "@angular/core": "^16.1.5"
+    "@angular/common": "^16 || ^17 || ^18",
+    "@angular/core": "^16 || ^17 || ^18"
   },
   "dependencies": {
     "tslib": "^2.4.1"


### PR DESCRIPTION
With this commit, validointi will now support installing in V17 or v18 projects

none
