### PR TITLE
fix(core): correct peer dependency range for @angular/core

### DIFF
--- a/projects/validointi/core/package.json
+++ b/projects/validointi/core/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/validointi/validointi/tree/main/projects/validointi/core"
   },
   "peerDependencies": {
-    "@angular/core": "17.0.0 - 21.0.0 "
+    "@angular/core": ">=17.0.0 <21.0.0"
   },
   "dependencies": {
     "tslib": "^2.8.1"


### PR DESCRIPTION
Updated the peerDependencies in package.json to use the correct version range (>=17.0.0 <21.0.0) for @angular/core.